### PR TITLE
Add event name settings and receipt image

### DIFF
--- a/src/components/SaleRegister.vue
+++ b/src/components/SaleRegister.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="mx-auto my-2" max-width="480" elevation="5">
-    <v-card-title class="text-h6 text-center">Registar Venda</v-card-title>
+    <v-card-title class="text-h6 text-center">{{ eventName.value || 'Registar Venda' }}</v-card-title>
     <v-card-text class="pa-2">
       <v-form @submit.prevent="addItem" v-if="!saleComplete">
         <v-row class="g-1" align="center">
@@ -56,16 +56,18 @@
         <div class="text-end text-h6">Valor dado: <strong class="text-warning">€{{ lastSale.given.toFixed(2) }}</strong>
         </div>
         <div class="text-end text-h5">Troco: <strong class="text-error">€{{ lastSale.change }}</strong></div>
-        <v-btn color="primary" block class="mt-4" @click="novaVenda">Nova Venda</v-btn>
+        <v-btn color="secondary" block class="mt-4" @click="gerarTalao">Gerar Talão</v-btn>
+        <v-btn color="primary" block class="mt-2" @click="novaVenda">Nova Venda</v-btn>
       </div>
     </v-card-text>
   </v-card>
 </template>
 <script setup>
-import { ref, computed, toRefs } from 'vue'
+import { ref, computed, toRefs, inject } from 'vue'
 const props = defineProps(['products'])
 const emit = defineEmits(['sale-registered'])
 const { products } = toRefs(props)
+const eventName = inject('eventName')
 
 const currentItem = ref({ product: '', quantity: 1 })
 const cart = ref([])
@@ -116,6 +118,40 @@ function finalizeSale() {
   emit('sale-registered', reg)
   lastSale.value = reg
   saleComplete.value = true
+}
+function gerarTalao() {
+  if (!lastSale.value.items.length) return
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+  const lineHeight = 20
+  const margin = 10
+  const lines = []
+  lines.push(eventName.value || 'Venda')
+  lines.push('----------------')
+  lastSale.value.items.forEach(it => {
+    const total = getProductPrice(it.product, it.quantity)
+    lines.push(`${it.product} x${it.quantity} = €${total}`)
+  })
+  lines.push('----------------')
+  lines.push(`Total: €${lastSale.value.total.toFixed(2)}`)
+  lines.push(`Valor dado: €${lastSale.value.given.toFixed(2)}`)
+  lines.push(`Troco: €${lastSale.value.change}`)
+  lines.push(new Date(lastSale.value.date).toLocaleString())
+  lines.push('Este talão não tem valor legal')
+  canvas.width = 280
+  canvas.height = margin * 2 + lines.length * lineHeight
+  ctx.fillStyle = '#fff'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  ctx.fillStyle = '#000'
+  ctx.font = '16px sans-serif'
+  lines.forEach((line, idx) => {
+    ctx.fillText(line, margin, margin + idx * lineHeight)
+  })
+  const url = canvas.toDataURL('image/png')
+  const link = document.createElement('a')
+  link.href = url
+  link.download = 'talao.png'
+  link.click()
 }
 function novaVenda() {
   cart.value = []

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -25,15 +25,16 @@
   </v-app>
 </template>
 <script setup>
-import { ref, provide } from 'vue'
+import { ref, provide, watch } from 'vue'
 const logoSrc = '/fastpos-logo.png'
 const drawer = ref(false)
 // STATE PARTILHADO igual ao anterior...
-import { watch } from 'vue'
 const products = ref(JSON.parse(localStorage.getItem('sales_products')||'[]'))
 const sales = ref(JSON.parse(localStorage.getItem('sales_data')||'[]'))
 const saleSeq = ref(Number(localStorage.getItem('sales_seq')||1))
+const eventName = ref(localStorage.getItem('event_name') || '')
 function updateProducts(newList){ products.value = newList }
+function setEventName(name){ eventName.value = name }
 function registerSale(sale){
   sales.value.push({ ...sale, seq: saleSeq.value })
   saleSeq.value++
@@ -42,9 +43,12 @@ function closeDay(){ sales.value = [] }
 watch(products, v => localStorage.setItem('sales_products', JSON.stringify(v)), { deep:true })
 watch(sales, v => localStorage.setItem('sales_data', JSON.stringify(v)), { deep:true })
 watch(saleSeq, v => localStorage.setItem('sales_seq', v))
+watch(eventName, v => localStorage.setItem('event_name', v))
 provide('products', products)
 provide('sales', sales)
 provide('updateProducts', updateProducts)
 provide('registerSale', registerSale)
 provide('closeDay', closeDay)
+provide('eventName', eventName)
+provide('setEventName', setEventName)
 </script>

--- a/src/pages/ProductManagerPage.vue
+++ b/src/pages/ProductManagerPage.vue
@@ -1,4 +1,10 @@
 <template>
+  <v-card class="mx-auto my-4" max-width="480" elevation="5">
+    <v-card-title class="text-h6 text-center">Configurações</v-card-title>
+    <v-card-text>
+      <v-text-field v-model="eventName.value" label="Nome do evento" density="comfortable" hide-details />
+    </v-card-text>
+  </v-card>
   <ProductManager :products="products" @update="updateProducts" />
 </template>
 <script setup>
@@ -6,4 +12,5 @@ import { inject } from 'vue'
 import ProductManager from '../components/ProductManager.vue'
 const products = inject('products')
 const updateProducts = inject('updateProducts')
+const eventName = inject('eventName')
 </script>


### PR DESCRIPTION
## Summary
- allow configuring an event name
- show the event name on the Register Sale card
- generate receipt image from sale summary

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1b3dfd688332a528e6badaf7ab5e