### PR TITLE
Prevent editing/removing sold products

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Sistema de Registo de Vendas moderno, desenvolvido em Vue 3 com Vuetify 3, 100% 
 
 * Criar, editar e remover produtos
 * Definir o valor de venda de cada produto
+* Produtos já vendidos permanecem visíveis na lista, mas os botões de editar ou remover ficam desabilitados
 
 ### Registar Venda
 

--- a/src/components/ProductManager.vue
+++ b/src/components/ProductManager.vue
@@ -39,8 +39,12 @@
             {{ p.name }} <span class="grey--text">— €{{ p.price.toFixed(2) }}</span>
           </v-list-item-title>
           <template #append>
-            <v-btn icon @click="edit(idx)" size="x-small"><v-icon size="x-small">mdi-pencil</v-icon></v-btn>
-            <v-btn icon @click="remove(idx)" size="x-small" color="red"><v-icon size="x-small">mdi-delete</v-icon></v-btn>
+            <v-btn icon @click="edit(idx)" size="x-small" :disabled="productHasSales(p.name)">
+              <v-icon size="x-small">mdi-pencil</v-icon>
+            </v-btn>
+            <v-btn icon @click="remove(idx)" size="x-small" color="red" :disabled="productHasSales(p.name)">
+              <v-icon size="x-small">mdi-delete</v-icon>
+            </v-btn>
           </template>
         </v-list-item>
       </v-list>
@@ -48,10 +52,11 @@
   </v-card>
 </template>
 <script setup>
-import { ref, toRefs } from 'vue'
+import { ref, toRefs, inject } from 'vue'
 const props = defineProps(['products'])
 const emit = defineEmits(['update'])
 const { products } = toRefs(props)
+const sales = inject('sales', ref([]))
 const editProduct = ref({ name: '', price: null })
 const editIdx = ref(null)
 function saveProduct() {
@@ -67,6 +72,8 @@ function saveProduct() {
   editIdx.value = null
 }
 function edit(idx) {
+  const name = products.value[idx]?.name
+  if (productHasSales(name)) return
   editIdx.value = idx
   editProduct.value = { ...products.value[idx] }
 }
@@ -75,8 +82,19 @@ function cancelEdit() {
   editProduct.value = { name: '', price: null }
 }
 function remove(idx) {
+  const name = products.value[idx]?.name
+  if (productHasSales(name)) return
   let updated = [...products.value]
   updated.splice(idx, 1)
   emit('update', updated)
+}
+
+function productHasSales(name) {
+  if (!sales?.value || !Array.isArray(sales.value)) return false
+  const target = String(name).trim().toLowerCase()
+  return sales.value.some(sale =>
+    Array.isArray(sale.items) &&
+    sale.items.some(it => String(it.product).trim().toLowerCase() === target)
+  )
 }
 </script>


### PR DESCRIPTION
## Summary
- lock editing or deleting products that are already referenced in sales and keep buttons visible
- document that sold products stay visible but actions are disabled
- remove alert popups for blocked edits/removals

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d330307d08332abc59d59f4b1b60f