### PR TITLE
Adiciona ícones ao menu e ajuda

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -7,18 +7,18 @@
       <v-spacer />
       <v-app-bar-nav-icon class="d-md-none" @click="drawer = !drawer" />
       <v-row class="d-none d-md-flex" no-gutters align="center">
-        <v-btn to="/" text tag="router-link">Registar Venda</v-btn>
-        <v-btn to="/produtos" text tag="router-link">Produtos</v-btn>
-        <v-btn to="/resumo" text tag="router-link">Resumo do Dia</v-btn>
-        <v-btn to="/ajuda" text tag="router-link">Ajuda</v-btn>
+        <v-btn to="/" text tag="router-link" prepend-icon="mdi-cash-register">Registar Venda</v-btn>
+        <v-btn to="/produtos" text tag="router-link" prepend-icon="mdi-package-variant">Produtos</v-btn>
+        <v-btn to="/resumo" text tag="router-link" prepend-icon="mdi-chart-bar">Resumo do Dia</v-btn>
+        <v-btn to="/ajuda" text tag="router-link" prepend-icon="mdi-help-circle">Ajuda</v-btn>
       </v-row>
     </v-app-bar>
     <v-navigation-drawer v-model="drawer" app temporary class="d-md-none">
       <v-list>
-        <v-list-item to="/" tag="router-link">Registar Venda</v-list-item>
-        <v-list-item to="/produtos" tag="router-link">Produtos</v-list-item>
-        <v-list-item to="/resumo" tag="router-link">Resumo do Dia</v-list-item>
-        <v-list-item to="/ajuda" tag="router-link">Ajuda</v-list-item>
+        <v-list-item to="/" tag="router-link" prepend-icon="mdi-cash-register">Registar Venda</v-list-item>
+        <v-list-item to="/produtos" tag="router-link" prepend-icon="mdi-package-variant">Produtos</v-list-item>
+        <v-list-item to="/resumo" tag="router-link" prepend-icon="mdi-chart-bar">Resumo do Dia</v-list-item>
+        <v-list-item to="/ajuda" tag="router-link" prepend-icon="mdi-help-circle">Ajuda</v-list-item>
       </v-list>
     </v-navigation-drawer>
     <v-main>

--- a/src/pages/HelpPage.vue
+++ b/src/pages/HelpPage.vue
@@ -5,22 +5,22 @@
       <p>Esta aplicação permite gerir vendas de forma simples e rápida. Abaixo encontram-se as principais
         funcionalidades:</p>
       <v-list density="compact" class="bg-transparent">
-        <v-list-item variant="tonal">Registar Venda</v-list-item>
-        <v-list-item>Adicionar vários produtos à venda com quantidades</v-list-item>
-        <v-list-item>Ver preço unitário e subtotal por item</v-list-item>
-        <v-list-item>Calcular total da venda</v-list-item>
-        <v-list-item>Introduzir valor dado pelo cliente e calcular troco</v-list-item>
-        <v-list-item variant="tonal">Produtos</v-list-item>
-        <v-list-item>Nome do Evento</v-list-item>
-        <v-list-item>Criar, editar e remover produtos</v-list-item>
-        <v-list-item>Definir o valor de venda de cada produto</v-list-item>
-        <v-list-item>Produtos já vendidos permanecem visíveis na lista, mas os botões de editar ou remover ficam
+        <v-list-item variant="tonal" prepend-icon="mdi-cash-register">Registar Venda</v-list-item>
+        <v-list-item prepend-icon="mdi-cart-plus">Adicionar vários produtos à venda com quantidades</v-list-item>
+        <v-list-item prepend-icon="mdi-tag">Ver preço unitário e subtotal por item</v-list-item>
+        <v-list-item prepend-icon="mdi-calculator">Calcular total da venda</v-list-item>
+        <v-list-item prepend-icon="mdi-cash-multiple">Introduzir valor dado pelo cliente e calcular troco</v-list-item>
+        <v-list-item variant="tonal" prepend-icon="mdi-package-variant">Produtos</v-list-item>
+        <v-list-item prepend-icon="mdi-calendar">Nome do Evento</v-list-item>
+        <v-list-item prepend-icon="mdi-pencil">Criar, editar e remover produtos</v-list-item>
+        <v-list-item prepend-icon="mdi-cash">Definir o valor de venda de cada produto</v-list-item>
+        <v-list-item prepend-icon="mdi-lock">Produtos já vendidos permanecem visíveis na lista, mas os botões de editar ou remover ficam
           desabilitados</v-list-item>
-        <v-list-item variant="tonal">Resumo do Dia</v-list-item>
-        <v-list-item>Mostrar totais por produto vendido (quantidade e valor)</v-list-item>
-        <v-list-item>Mostrar total global de vendas do dia</v-list-item>
-        <v-list-item>Possibilidade de "Fechar o dia" (limpa as vendas, mantém produtos)</v-list-item>
-        <v-list-item variant="plain">Aplicação PWA que funciona offline e guarda os dados localmente.</v-list-item>
+        <v-list-item variant="tonal" prepend-icon="mdi-chart-bar">Resumo do Dia</v-list-item>
+        <v-list-item prepend-icon="mdi-chart-box-outline">Mostrar totais por produto vendido (quantidade e valor)</v-list-item>
+        <v-list-item prepend-icon="mdi-cash">Mostrar total global de vendas do dia</v-list-item>
+        <v-list-item prepend-icon="mdi-close">Possibilidade de "Fechar o dia" (limpa as vendas, mantém produtos)</v-list-item>
+        <v-list-item variant="plain" prepend-icon="mdi-cloud-off-outline">Aplicação PWA que funciona offline e guarda os dados localmente.</v-list-item>
       </v-list>
     </v-card-text>
   </v-card>


### PR DESCRIPTION
## Summary
- adiciona ícones nas opções do menu principal
- inclui ícones em cada item da página de ajuda

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4b8fdd688332bce4ab9f1e683126