### PR TITLE
Improve mobile sale register usability

### DIFF
--- a/src/components/SaleRegister.vue
+++ b/src/components/SaleRegister.vue
@@ -12,18 +12,19 @@
           <v-list-item v-for="(p, idx) in products" :key="idx" class="py-2 px-0">
             <template #prepend>
               <div class="d-flex flex-column">
+                <span class="text-caption text-grey">{{ idx + 1 }}.</span>
                 <span class="text-body-2 font-weight-medium">{{ p.name }}</span>
                 <span class="text-caption text-grey">€{{ p.price.toFixed(2) }}</span>
               </div>
             </template>
             <template #append>
               <div class="d-flex align-center">
-                <v-btn icon size="x-small" @click="decrement(p.name)" :disabled="getQty(p.name) === 0">
-                  <v-icon size="x-small">mdi-minus</v-icon>
+                <v-btn icon size="large" @click="decrement(p.name)" :disabled="getQty(p.name) === 0">
+                  <v-icon size="large">mdi-minus</v-icon>
                 </v-btn>
-                <v-chip size="small" class="mx-1" color="primary" variant="elevated">{{ getQty(p.name) }}</v-chip>
-                <v-btn icon size="x-small" @click="increment(p.name)">
-                  <v-icon size="x-small">mdi-plus</v-icon>
+                <v-chip size="large" class="mx-1" color="primary" variant="elevated">{{ getQty(p.name) }}</v-chip>
+                <v-btn icon size="large" @click="increment(p.name)">
+                  <v-icon size="large">mdi-plus</v-icon>
                 </v-btn>
               </div>
             </template>


### PR DESCRIPTION
## Summary
- make plus/minus buttons and quantity chip larger
- show row number for each product in the register list

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875841b5afc8332b61ded1e972a8d74