### PR TITLE
Allow negative quantities for refunds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sistema de Registo de Vendas moderno, desenvolvido em Vue 3 com Vuetify 3, 100% 
 
 ### Registar Venda
 
-* Adicionar vários produtos à venda com quantidades
+* Adicionar vários produtos à venda com quantidades (incluindo negativas para trocas/devoluções)
 * Ver preço unitário e subtotal por item
 * Calcular total da venda
 * Introduzir valor dado pelo cliente e calcular troco


### PR DESCRIPTION
## Summary
- allow negative quantities in sale register
- mark negative items in red and color total if negative
- handle cash to refund customers
- show refund info on receipt
- document negative quantity support

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876bb6dc5d883328185cfe3114ff8cb